### PR TITLE
feat(manifest): read and parse manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,20 @@
 BIN=bin
 
-# Build all binaries
 all: clean build-cli build-server
 
-# Build the CLI
 build-cli:
-	@echo "Building CLI..."
 	go build -ldflags="-s -w" -o $(BIN)/cli ./cmd/cli
 
-# Build the Server
+install-cli:
+	make build-cli
+	./scripts/install.sh -local bin/cli
+
 build-server:
-	@echo "Building Server..."
 	go build -ldflags="-s -w" -o $(BIN)/server ./cmd/server
 
-# Run the server locally
 run-server:
 	go run ./cmd/server/main.go
 
 # Clean build artifacts
 clean:
-	@echo "Cleaning..."
 	rm -rf $(BIN)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Push'N'Pray
 
 🙏 A platform as a service solution in Go.
+
+## CLI
+
+Push'N'Pray has a CLI that can installed by running this in your terminal.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/do-2k25-28/Push-N-Pray/refs/heads/main/scripts/install.sh | bash
+```

--- a/cmd/cli/cmd/init.go
+++ b/cmd/cli/cmd/init.go
@@ -1,18 +1,61 @@
 package cmd
 
 import (
+	"os"
+	"pushnpray/internal/manifest"
+
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
+
+var manifestPath string = ""
+
+var projectName string
+var repositoryUrl string
 
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a new project",
 	Long:  `Create a project on the platform using the current repository metadata and store the project id locally.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		file, err := cmd.Root().Flags().GetString("file")
+		if err != nil {
+			return err
+		}
 
+		manifestPath = file
+
+		// TODO: Check if user is logged in
+
+		return nil
 	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// TODO: POST v1/projects
+
+		// TODO: Get it from the response
+		projectId := uuid.New()
+
+		man := manifest.Manifest{
+			ProjectId:     projectId.String(),
+			RepositoryUrl: repositoryUrl,
+		}
+
+		data, err := manifest.Marshal(&man)
+		if err != nil {
+			return err
+		}
+
+		return os.WriteFile(manifestPath, data, 0644)
+	},
+	SilenceUsage: true,
 }
 
 func init() {
 	rootCmd.AddCommand(initCmd)
+
+	initCmd.Flags().StringVarP(&projectName, "name", "n", "", "Name for your new project")
+	initCmd.Flags().StringVarP(&repositoryUrl, "repository", "r", "", "URL of the repository (must be http(s))")
+
+	var _ = initCmd.MarkFlagRequired("name")
+	var _ = initCmd.MarkFlagRequired("repository")
 }

--- a/cmd/cli/cmd/init.go
+++ b/cmd/cli/cmd/init.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +9,7 @@ var initCmd = &cobra.Command{
 	Short: "Initialize a new project",
 	Long:  `Create a project on the platform using the current repository metadata and store the project id locally.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("init called")
+
 	},
 }
 

--- a/cmd/cli/cmd/login.go
+++ b/cmd/cli/cmd/login.go
@@ -10,23 +10,10 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Authenticate with email/password or a personal access token",
 	Long:  "Start a session by exchanging credentials for tokens and storing them locally for future commands.",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		password, _ := cmd.Flags().GetString("password")
-		token, _ := cmd.Flags().GetString("token")
-
-		if password == "" && token == "" {
-			return fmt.Errorf("login requires either a password or a token")
-		}
-
-		if password != "" && token != "" {
-			return fmt.Errorf("use either password or token but not both")
-		}
-
-		return nil
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("login called")
 	},
+	SilenceUsage: true,
 }
 
 func init() {
@@ -36,7 +23,7 @@ func init() {
 	loginCmd.Flags().StringP("password", "p", "", "Account password")
 	loginCmd.Flags().StringP("token", "t", "", "Personnal access token")
 
-	if err := loginCmd.MarkFlagRequired("username"); err != nil {
-		panic(err)
-	}
+	loginCmd.MarkFlagsOneRequired("password", "token")
+	loginCmd.MarkFlagsMutuallyExclusive("password", "token")
+	var _ = loginCmd.MarkFlagRequired("username")
 }

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -26,6 +26,8 @@ func Execute() {
 func init() {
 	rootCmd.Flags().StringP("file", "f", "pushnpray.toml", "Path to a project manifest")
 
+	var _ = rootCmd.MarkFlagFilename("file", "toml")
+
 	rootCmd.AddCommand(env.EnvCmd)
 	rootCmd.AddCommand(pat.PatCmd)
 	rootCmd.AddCommand(project.ProjectCmd)

--- a/cmd/cli/cmd/version.go
+++ b/cmd/cli/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Display CLI version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -198,12 +198,8 @@ Authorization: Bearer <accessToken>
 Content-Type: application/json
 
 {
-  "name": "My revolutionary project",
   "slug": "my-revolutionary-project",
-  "repository": {
-    "url": "https://github.com/RichardDorian/CitiesAPI.git",
-    "branch": "main"
-  }
+  "repositoryUrl": "https://github.com/RichardDorian/CitiesAPI.git"
 }
 ```
 
@@ -266,6 +262,11 @@ or
 POST /v1/projects/:projectId/deploy
 
 Authorization: Bearer <accessToken>
+Content-Type: application/json
+
+{
+  "branch": "main"
+}
 ```
 
 ```http

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/docker/go-sdk/image v0.1.0-alpha014
 	github.com/docker/go-sdk/network v0.1.0-alpha013
 	github.com/gin-gonic/gin v1.12.0
+	github.com/google/uuid v1.6.0
 )
 
 require (
@@ -30,7 +31,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.1.0 // indirect
@@ -74,7 +74,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
-github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=

--- a/internal/manifest/marshal.go
+++ b/internal/manifest/marshal.go
@@ -1,0 +1,26 @@
+package manifest
+
+import (
+	"os"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+func Marshal(manifest *Manifest) ([]byte, error) {
+	return toml.Marshal(manifest)
+}
+
+func Unmarshal(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest Manifest
+	err = toml.Unmarshal(data, &manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}

--- a/internal/manifest/struct.go
+++ b/internal/manifest/struct.go
@@ -16,6 +16,7 @@ type DockerApp struct {
 }
 
 type Service struct {
+	Name string
 }
 
 type PostgresService struct {
@@ -32,18 +33,18 @@ type S3Service struct {
 	Service
 }
 
-var Manifest struct {
+type Manifest struct {
 	ProjectId     string `toml:"project-id"`
 	RepositoryUrl string `toml:"repository-url"`
 
 	Apps struct {
-		Dockerfile []DockerFileApp
-		Docker     []DockerApp
-	}
+		Dockerfile []DockerFileApp `toml:"dockerfile,omitempty"`
+		Docker     []DockerApp     `toml:"docker,omitempty"`
+	} `toml:"apps,omitempty"`
 
 	Services struct {
-		Postgres []PostgresService
-		Redis    []RedisService
-		S3       []S3Service
-	}
+		Postgres []PostgresService `toml:"postgres,omitempty"`
+		Redis    []RedisService    `toml:"redis,omitempty"`
+		S3       []S3Service       `toml:"s3,omitempty"`
+	} `toml:"services,omitempty"`
 }

--- a/internal/manifest/struct.go
+++ b/internal/manifest/struct.go
@@ -1,0 +1,49 @@
+package manifest
+
+type App struct {
+	Name string
+}
+
+type DockerFileApp struct {
+	App
+	Dockerfile string
+	Context    string
+}
+
+type DockerApp struct {
+	App
+	Image string
+}
+
+type Service struct {
+}
+
+type PostgresService struct {
+	Service
+	Version string
+}
+
+type RedisService struct {
+	Service
+	Version string
+}
+
+type S3Service struct {
+	Service
+}
+
+var Manifest struct {
+	ProjectId     string `toml:"project-id"`
+	RepositoryUrl string `toml:"repository-url"`
+
+	Apps struct {
+		Dockerfile []DockerFileApp
+		Docker     []DockerApp
+	}
+
+	Services struct {
+		Postgres []PostgresService
+		Redis    []RedisService
+		S3       []S3Service
+	}
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+if [ "$(uname -ms)" != "Linux x86_64" ]; then
+  echo "Install script only supports Linux x86_64"
+  exit 1
+fi
+
+TARGET="$HOME/.local/bin/pushnpray"
+
+if [ "$1" = "-local" ]; then
+  echo "Installing from local file ($2)"
+  mv "$2" "$TARGET"
+else
+  echo "Downloading from latest GitHub release"
+  curl -fs -O "$TARGET" https://github.com/do-2k25-28/Push-N-Pray/releases/latest/download/pushnpray-linux-amd64
+  chmod +x "$TARGET"
+fi
+
+case $(basename "$SHELL") in
+bash)
+  echo "Adding bash completions"
+  mkdir -p "$HOME/.local/share/bash-completion/completions"
+  pushnpray completion bash > "$HOME/.local/share/bash-completion/completions/pushnpray"
+  ;;
+*)
+  echo "Install script doesn't support your shell completions"
+  ;;
+esac
+
+echo "Successfuly installed Push'N'Pray command line interface $(pushnpray version)"


### PR DESCRIPTION
- Add install script for the CLI that supports shell completions (currently only bash)
- Add manifest parsing in toml
  - Marshal/Unmarshal
- Implement init command with a placeholder `projectId`
- Improved flag validation for `login`, `root` and `init` commands