### PR TITLE
fix(makefile): fix run server command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ install-cli:
 build-server:
 	go build -ldflags="-s -w" -o $(BIN)/server ./cmd/server
 
-run-server:
-	go run ./cmd/server/main.go
+run:
+	go run ./cmd/server
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
- The `run-server` target was renamed to `run`
- Fixes the dev run backend server command  