### PR TITLE
feat(server): use docker in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ USER nonroot:nonroot
 
 COPY --from=builder /out/server /usr/local/bin/push-n-pray
 
+ENV GIN_MODE=release
+ENV HTTP_PORT=80
+
 EXPOSE 80
 
 ENTRYPOINT ["/usr/local/bin/push-n-pray"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM golang:1.26.2
+
+WORKDIR /src
+
+# Cache dependencies first
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+CMD ["go", "run", "./cmd/server"]

--- a/cmd/server/api/handlers.go
+++ b/cmd/server/api/handlers.go
@@ -7,7 +7,7 @@ import (
 	"pushnpray/cmd/server/database"
 	"pushnpray/cmd/server/deployment"
 	"pushnpray/cmd/server/models"
-	"pushnpray/internal"
+	"pushnpray/internal/docker"
 	pkgapi "pushnpray/pkg/api"
 
 	"github.com/gin-gonic/gin"
@@ -48,17 +48,17 @@ func DeleteProject(c *gin.Context) {
 	}
 
 	pattern := fmt.Sprintf("%s-%s", project.Slug, project.ID)
-	dockerClient, err := internal.NewClient(c.Request.Context())
+	dockerClient, err := docker.NewClient(c.Request.Context())
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": internal.ErrDockerStopRemoveFailed})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": docker.ErrDockerStopRemoveFailed})
 		return
 	}
 	if err := dockerClient.StopContainersByPattern(c.Request.Context(), pattern); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": internal.ErrDockerStopRemoveFailed})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": docker.ErrDockerStopRemoveFailed})
 		return
 	}
 	if err := dockerClient.RemoveContainersByPattern(c.Request.Context(), pattern); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": internal.ErrDockerStopRemoveFailed})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": docker.ErrDockerStopRemoveFailed})
 	}
 
 	if err := database.GetDB().Delete(&project).Error; err != nil {

--- a/cmd/server/deployment/deploy.go
+++ b/cmd/server/deployment/deploy.go
@@ -38,6 +38,12 @@ func (s *DeployService) DeployProject(projectSlug string, projectID string, m *m
 
 	for _, app := range m.Apps.Docker {
 		containerName := fmt.Sprintf("%s-%s-%s", app.Name, projectSlug, projectID)
+
+		fmt.Printf("Pulling image %s\n", app.Image)
+		if err := dockerClient.PullImages(ctx, app.Image); err != nil {
+			return fmt.Errorf("unable to pull image %s, %w", app.Image, err)
+		}
+
 		fmt.Printf("Deploying Docker image app: %s\n", app.Name)
 		if err := dockerClient.RunContainer(ctx, containerName, app.Image); err != nil {
 			return fmt.Errorf(errFmtAppRunFailed+": %w", app.Name, err)

--- a/cmd/server/deployment/deploy.go
+++ b/cmd/server/deployment/deploy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"pushnpray/cmd/server/utils"
-	"pushnpray/internal"
+	"pushnpray/internal/docker"
 	"pushnpray/internal/manifest"
 )
 
@@ -16,7 +16,7 @@ func NewDeployService() *DeployService {
 
 func (s *DeployService) DeployProject(projectSlug string, projectID string, m *manifest.Manifest, workspaceDir string) error {
 	ctx := context.Background()
-	dockerClient, err := internal.NewClient(ctx)
+	dockerClient, err := docker.NewClient(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create docker client: %w", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,11 +7,11 @@ import (
 	"pushnpray/cmd/server/api"
 	"pushnpray/cmd/server/database"
 	"pushnpray/cmd/server/utils"
-	"pushnpray/internal"
+	"pushnpray/internal/docker"
 )
 
 func main() {
-	if !internal.CheckIfDockerInstalled() {
+	if !docker.CheckIfDockerInstalled() {
 		log.Fatalf("Docker is not installed or not available in PATH. Please install Docker before running this server.")
 		os.Exit(1)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,15 +7,9 @@ import (
 	"pushnpray/cmd/server/api"
 	"pushnpray/cmd/server/database"
 	"pushnpray/cmd/server/utils"
-	"pushnpray/internal/docker"
 )
 
 func main() {
-	if !docker.CheckIfDockerInstalled() {
-		log.Fatalf("Docker is not installed or not available in PATH. Please install Docker before running this server.")
-		os.Exit(1)
-	}
-
 	database.InitDB()
 
 	router := api.NewRouter()

--- a/compose.yml
+++ b/compose.yml
@@ -7,8 +7,45 @@ services:
     volumes:
       - postgres:/var/lib/postgresql
       - ./db-init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d pushnpray"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     ports:
       - 5432:5432
 
+  docker:
+    image: library/docker:29.5.2-dind
+    privileged: 'true'
+    command: ['dockerd', '-H', 'tcp://0.0.0.0:2375', '--tls=false']
+    restart: 'unless-stopped'
+
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+      - go_build_cache:/root/.cache/go-build
+    environment:
+      DOCKER_HOST: tcp://docker:2375
+      DB_HOST: postgres
+      DB_PASSWORD: postgres
+      DB_NAME: pushnpray
+    depends_on:
+      postgres:
+        condition: service_healthy
+    develop:
+      watch:
+        - path: .
+          target: /src
+          action: sync+restart
+          ignore:
+            - Dockerfile.dev
+        - path: Dockerfile.dev
+          action: rebuild
+
 volumes:
   postgres:
+  go_build_cache:

--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,8 @@ services:
       DB_HOST: postgres
       DB_PASSWORD: postgres
       DB_NAME: pushnpray
+    ports:
+      - 4000:4000
     depends_on:
       postgres:
         condition: service_healthy

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os/exec"
 	"path/filepath"
 	"sync"
 
@@ -241,10 +240,4 @@ func (c *Client) RemoveContainersByPattern(ctx context.Context, pattern string) 
 		return fmt.Errorf("dockerwrapper: RemoveContainersByPattern: %w", errors.Join(errs...))
 	}
 	return nil
-}
-
-// CheckIfDockerInstalled returns true if the Docker CLI is available in the system PATH.
-func CheckIfDockerInstalled() bool {
-	_, err := exec.LookPath("docker")
-	return err == nil
 }

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 
@@ -16,6 +17,8 @@ import (
 	"github.com/moby/moby/api/types/container"
 	dockerclient "github.com/moby/moby/client"
 )
+
+var defaultDockerSocket = "/var/run/docker/sock"
 
 type Client struct {
 	docker dockerSdk.SDKClient
@@ -34,7 +37,13 @@ type ContainerConfig struct {
 }
 
 func NewClient(ctx context.Context) (*Client, error) {
-	client, err := dockerSdk.New(ctx)
+	dockerHost := os.Getenv("DOCKER_HOST")
+
+	if dockerHost == "" {
+		dockerHost = defaultDockerSocket
+	}
+
+	client, err := dockerSdk.New(ctx, dockerSdk.WithDockerHost(dockerHost))
 
 	if err != nil {
 		return nil, fmt.Errorf("dockerwrapper: create client: %w", err)
@@ -56,6 +65,7 @@ func (c *Client) PullImages(ctx context.Context, images ...string) error {
 		wg.Add(1)
 		go func(img string) {
 			defer wg.Done()
+
 			if err := sdkimage.Pull(ctx, img, sdkimage.WithPullClient(c.docker)); err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Errorf("pull %q: %w", img, err))

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -52,6 +52,11 @@ func NewClient(ctx context.Context) (*Client, error) {
 	return &Client{docker: client}, nil
 }
 
+// We only support docker hub so no registry
+func registryCredentials(image string) (string, string, error) {
+	return "", "", nil
+}
+
 // PullImages pulls images concurrently. All pulls are attempted; errors are
 // collected and returned as a single joined error.
 func (c *Client) PullImages(ctx context.Context, images ...string) error {
@@ -66,7 +71,7 @@ func (c *Client) PullImages(ctx context.Context, images ...string) error {
 		go func(img string) {
 			defer wg.Done()
 
-			if err := sdkimage.Pull(ctx, img, sdkimage.WithPullClient(c.docker)); err != nil {
+			if err := sdkimage.Pull(ctx, img, sdkimage.WithPullClient(c.docker), sdkimage.WithCredentialsFn(registryCredentials)); err != nil {
 				mu.Lock()
 				errs = append(errs, fmt.Errorf("pull %q: %w", img, err))
 				mu.Unlock()

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -1,6 +1,6 @@
 // Package dockerwrapper abstracts Docker operations for pulling images,
 // creating networks, and creating containers.
-package internal
+package docker
 
 import (
 	"context"

--- a/internal/mod.go
+++ b/internal/mod.go
@@ -1,0 +1,1 @@
+package internal


### PR DESCRIPTION
- Move wrapper into appropriate package
- Remove docker binary path check -> communication with the docker daemon is done through the unix socket by default or tcp
- The server now reads the `DOCKER_HOST` environment variable and passes it to the sdk. If no value is supplied, it falls back to the default socket `/var/run/docker.sock`.
- Set `GIN_MODE` to `release` in container image
- Added empty registry credentials when pulling images because in dind there's no config on the file system