### PR TITLE
feat: add a lifecycle api for managed services

### DIFF
--- a/cmd/server/api/routes/projects.go
+++ b/cmd/server/api/routes/projects.go
@@ -78,9 +78,7 @@ func DeleteProject(c *gin.Context) {
 		return
 	}
 	for _, service := range services {
-		if service.ContainerName != "" {
-			excludedContainers[service.ContainerName] = struct{}{}
-		}
+		excludedContainers[service.ContainerName] = struct{}{}
 	}
 
 	dockerClient, err := internal.NewClient(c.Request.Context())

--- a/cmd/server/api/routes/projects.go
+++ b/cmd/server/api/routes/projects.go
@@ -71,17 +71,30 @@ func DeleteProject(c *gin.Context) {
 	project := c.MustGet("project").(models.Project)
 
 	pattern := fmt.Sprintf("%s-%s", project.Slug, project.ID)
+	excludedContainers := map[string]struct{}{}
+	var services []models.ManagedService
+	if err := database.GetDB().Where("project_id = ? AND status <> ?", project.ID, models.ServiceDeleted).Find(&services).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrServiceListFailed})
+		return
+	}
+	for _, service := range services {
+		if service.ContainerName != "" {
+			excludedContainers[service.ContainerName] = struct{}{}
+		}
+	}
+
 	dockerClient, err := internal.NewClient(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": internal.ErrDockerStopRemoveFailed})
 		return
 	}
-	if err := dockerClient.StopContainersByPattern(c.Request.Context(), pattern); err != nil {
+	if err := dockerClient.StopContainersByPatternExcept(c.Request.Context(), pattern, excludedContainers); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": internal.ErrDockerStopRemoveFailed})
 		return
 	}
-	if err := dockerClient.RemoveContainersByPattern(c.Request.Context(), pattern); err != nil {
+	if err := dockerClient.RemoveContainersByPatternExcept(c.Request.Context(), pattern, excludedContainers); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": internal.ErrDockerStopRemoveFailed})
+		return
 	}
 
 	if err := database.GetDB().Delete(&project).Error; err != nil {

--- a/cmd/server/api/routes/router.go
+++ b/cmd/server/api/routes/router.go
@@ -60,5 +60,12 @@ func NewRouter() *gin.Engine {
 		c.Status(http.StatusNoContent)
 	})
 
+	// Managed services
+	services := router.Group("/v1/projects/:projectId/services")
+	services.Use(middleware.Auth(), middleware.ProjectOwnership())
+
+	services.GET("", ListServices)
+	services.DELETE("/:serviceId", DeleteService)
+
 	return router
 }

--- a/cmd/server/api/routes/services.go
+++ b/cmd/server/api/routes/services.go
@@ -37,11 +37,6 @@ func DeleteService(c *gin.Context) {
 		return
 	}
 
-	if service.Status == models.ServiceDeleted {
-		c.Status(http.StatusNoContent)
-		return
-	}
-
 	dockerClient, err := internal.NewClient(c.Request.Context())
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrServiceDeleteFailed})
@@ -54,7 +49,6 @@ func DeleteService(c *gin.Context) {
 	}
 
 	service.Status = models.ServiceDeleted
-	service.Message = "Service deleted"
 	if err := database.GetDB().Save(&service).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrServiceDeleteFailed})
 		return

--- a/cmd/server/api/routes/services.go
+++ b/cmd/server/api/routes/services.go
@@ -1,0 +1,64 @@
+package routes
+
+import (
+	"net/http"
+	"pushnpray/cmd/server/database"
+	"pushnpray/cmd/server/models"
+	"pushnpray/internal"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	ErrServiceNotFound     = "Service not found"
+	ErrServiceListFailed   = "Failed to list services"
+	ErrServiceDeleteFailed = "Failed to delete service"
+)
+
+func ListServices(c *gin.Context) {
+	project := c.MustGet("project").(models.Project)
+
+	var services []models.ManagedService
+	if err := database.GetDB().Where("project_id = ?", project.ID).Order("created_at desc").Find(&services).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrServiceListFailed})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"services": services})
+}
+
+func DeleteService(c *gin.Context) {
+	project := c.MustGet("project").(models.Project)
+	serviceID := c.Param("serviceId")
+
+	var service models.ManagedService
+	if err := database.GetDB().First(&service, "id = ? AND project_id = ?", serviceID, project.ID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": ErrServiceNotFound})
+		return
+	}
+
+	if service.Status == models.ServiceDeleted {
+		c.Status(http.StatusNoContent)
+		return
+	}
+
+	dockerClient, err := internal.NewClient(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrServiceDeleteFailed})
+		return
+	}
+
+	if err := dockerClient.RemoveManagedServiceResources(c.Request.Context(), service.ContainerName, service.VolumeName); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrServiceDeleteFailed})
+		return
+	}
+
+	service.Status = models.ServiceDeleted
+	service.Message = "Service deleted"
+	if err := database.GetDB().Save(&service).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrServiceDeleteFailed})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/cmd/server/database/db.go
+++ b/cmd/server/database/db.go
@@ -58,7 +58,7 @@ func InitDB() {
 		log.Fatal("failed to connect database: ", err)
 	}
 
-	if err := dbInstance.AutoMigrate(&models.Project{}, &models.Deployment{}); err != nil {
+	if err := dbInstance.AutoMigrate(&models.Project{}, &models.Deployment{}, &models.ManagedService{}); err != nil {
 		log.Fatal("failed to migrate database: ", err)
 	}
 }

--- a/cmd/server/models/managed_service.go
+++ b/cmd/server/models/managed_service.go
@@ -2,30 +2,21 @@ package models
 
 import "time"
 
-type ManagedServiceType string
-
 const (
-	PostgresService ManagedServiceType = "postgres"
-)
-
-type ManagedServiceStatus string
-
-const (
-	ServiceProvisioning ManagedServiceStatus = "provisioning"
-	ServiceRunning      ManagedServiceStatus = "running"
-	ServiceError        ManagedServiceStatus = "error"
-	ServiceDeleted      ManagedServiceStatus = "deleted"
+	ServiceProvisioning = "provisioning"
+	ServiceRunning      = "running"
+	ServiceError        = "error"
+	ServiceDeleted      = "deleted"
 )
 
 type ManagedService struct {
-	ID            string               `gorm:"primaryKey" json:"id"`
-	ProjectID     string               `gorm:"index;not null" json:"projectId"`
-	Name          string               `gorm:"not null" json:"name"`
-	Type          ManagedServiceType   `gorm:"not null" json:"type"`
-	Status        ManagedServiceStatus `gorm:"not null" json:"status"`
-	ContainerName string               `json:"containerName,omitempty"`
-	VolumeName    string               `json:"volumeName,omitempty"`
-	Message       string               `json:"message,omitempty"`
-	CreatedAt     time.Time            `json:"createdAt"`
-	UpdatedAt     time.Time            `json:"updatedAt"`
+	ID            string    `gorm:"primaryKey" json:"id"`
+	ProjectID     string    `gorm:"index;not null" json:"projectId"`
+	Name          string    `gorm:"not null" json:"name"`
+	Type          string    `gorm:"not null" json:"type"`
+	Status        string    `gorm:"not null" json:"status"`
+	ContainerName string    `json:"containerName,omitempty"`
+	VolumeName    string    `json:"volumeName,omitempty"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
 }

--- a/cmd/server/models/managed_service.go
+++ b/cmd/server/models/managed_service.go
@@ -1,0 +1,31 @@
+package models
+
+import "time"
+
+type ManagedServiceType string
+
+const (
+	PostgresService ManagedServiceType = "postgres"
+)
+
+type ManagedServiceStatus string
+
+const (
+	ServiceProvisioning ManagedServiceStatus = "provisioning"
+	ServiceRunning      ManagedServiceStatus = "running"
+	ServiceError        ManagedServiceStatus = "error"
+	ServiceDeleted      ManagedServiceStatus = "deleted"
+)
+
+type ManagedService struct {
+	ID            string               `gorm:"primaryKey" json:"id"`
+	ProjectID     string               `gorm:"index;not null" json:"projectId"`
+	Name          string               `gorm:"not null" json:"name"`
+	Type          ManagedServiceType   `gorm:"not null" json:"type"`
+	Status        ManagedServiceStatus `gorm:"not null" json:"status"`
+	ContainerName string               `json:"containerName,omitempty"`
+	VolumeName    string               `json:"volumeName,omitempty"`
+	Message       string               `json:"message,omitempty"`
+	CreatedAt     time.Time            `json:"createdAt"`
+	UpdatedAt     time.Time            `json:"updatedAt"`
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -351,3 +351,56 @@ Content-Type: application/json
 ```http
 HTTP/1.1 204 OK
 ```
+
+### List managed services
+
+List managed services attached to a project.
+
+```http
+GET /v1/projects/:projectId/services
+
+Authorization: Bearer <accessToken>
+```
+
+```http
+HTTP/1.1 200 OK
+
+Content-Type: application/json
+
+{
+  "services": [
+    {
+      "id": "86f7d497-45d5-4474-9b4d-61b70891e0e5",
+      "projectId": "p0ZoB1FwH6",
+      "name": "main-db",
+      "type": "postgres",
+      "status": "running",
+      "containerName": "postgres-main-db-p0ZoB1FwH6",
+      "volumeName": "postgres-main-db-p0ZoB1FwH6-data",
+      "createdAt": "2026-06-02T10:15:00Z",
+      "updatedAt": "2026-06-02T10:15:00Z"
+    }
+  ]
+}
+```
+
+| Status         | Description                                      |
+| -------------- | ------------------------------------------------ |
+| `provisioning` | Service creation is in progress.                 |
+| `running`      | Service is available.                            |
+| `error`        | Service provisioning or lifecycle action failed. |
+| `deleted`      | Service resources were explicitly deleted.       |
+
+### Delete managed service
+
+Delete a managed service explicitly. This stops and removes the service container and its dedicated volume when they are known by the control plane. Application deletion and redeployment do not call this route implicitly.
+
+```http
+DELETE /v1/projects/:projectId/services/:serviceId
+
+Authorization: Bearer <accessToken>
+```
+
+```http
+HTTP/1.1 204 No Content
+```

--- a/infrastructure/database/init.sql
+++ b/infrastructure/database/init.sql
@@ -39,7 +39,6 @@ CREATE TABLE IF NOT EXISTS managed_services (
     status VARCHAR(50) NOT NULL,
     container_name VARCHAR(255),
     volume_name VARCHAR(255),
-    message TEXT,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );

--- a/infrastructure/database/init.sql
+++ b/infrastructure/database/init.sql
@@ -30,3 +30,18 @@ CREATE TABLE IF NOT EXISTS deployments (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS managed_services (
+    id VARCHAR(255) PRIMARY KEY,
+    project_id VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    container_name VARCHAR(255),
+    volume_name VARCHAR(255),
+    message TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_managed_services_project_id ON managed_services(project_id);

--- a/internal/wrapper.go
+++ b/internal/wrapper.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	dockerSdk "github.com/docker/go-sdk/client"
@@ -206,14 +207,30 @@ func (c *Client) listContainersByPattern(ctx context.Context, pattern string) ([
 	return result.Items, nil
 }
 
+func isExcludedContainer(ctr container.Summary, excluded map[string]struct{}) bool {
+	for _, name := range ctr.Names {
+		if _, ok := excluded[strings.TrimPrefix(name, "/")]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // StopContainersByPattern stops all running containers whose names match the given pattern.
 func (c *Client) StopContainersByPattern(ctx context.Context, pattern string) error {
+	return c.StopContainersByPatternExcept(ctx, pattern, nil)
+}
+
+func (c *Client) StopContainersByPatternExcept(ctx context.Context, pattern string, excluded map[string]struct{}) error {
 	containers, err := c.listContainersByPattern(ctx, pattern)
 	if err != nil {
 		return err
 	}
 	var errs []error
 	for _, ctr := range containers {
+		if isExcludedContainer(ctr, excluded) {
+			continue
+		}
 		if _, err := c.docker.ContainerStop(ctx, ctr.ID, dockerclient.ContainerStopOptions{}); err != nil {
 			errs = append(errs, fmt.Errorf("stop %s: %w", ctr.ID, err))
 		}
@@ -226,18 +243,47 @@ func (c *Client) StopContainersByPattern(ctx context.Context, pattern string) er
 
 // RemoveContainersByPattern removes all containers whose names match the given pattern.
 func (c *Client) RemoveContainersByPattern(ctx context.Context, pattern string) error {
+	return c.RemoveContainersByPatternExcept(ctx, pattern, nil)
+}
+
+func (c *Client) RemoveContainersByPatternExcept(ctx context.Context, pattern string, excluded map[string]struct{}) error {
 	containers, err := c.listContainersByPattern(ctx, pattern)
 	if err != nil {
 		return err
 	}
 	var errs []error
 	for _, ctr := range containers {
+		if isExcludedContainer(ctr, excluded) {
+			continue
+		}
 		if _, err := c.docker.ContainerRemove(ctx, ctr.ID, dockerclient.ContainerRemoveOptions{Force: true}); err != nil {
 			errs = append(errs, fmt.Errorf("remove %s: %w", ctr.ID, err))
 		}
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("dockerwrapper: RemoveContainersByPattern: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
+func (c *Client) RemoveManagedServiceResources(ctx context.Context, containerName, volumeName string) error {
+	var errs []error
+
+	if containerName != "" {
+		_, _ = c.docker.ContainerStop(ctx, containerName, dockerclient.ContainerStopOptions{})
+		if _, err := c.docker.ContainerRemove(ctx, containerName, dockerclient.ContainerRemoveOptions{Force: true}); err != nil {
+			errs = append(errs, fmt.Errorf("remove service container %s: %w", containerName, err))
+		}
+	}
+
+	if volumeName != "" {
+		if _, err := c.docker.VolumeRemove(ctx, volumeName, dockerclient.VolumeRemoveOptions{Force: true}); err != nil {
+			errs = append(errs, fmt.Errorf("remove service volume %s: %w", volumeName, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("dockerwrapper: RemoveManagedServiceResources: %w", errors.Join(errs...))
 	}
 	return nil
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -230,6 +230,31 @@ func (c *Client) SetProjectEnv(ctx context.Context, projectID string, payload Se
 	return c.do(req, nil)
 }
 
+func (c *Client) ListManagedServices(ctx context.Context, projectID string) (*ListManagedServicesResponse, error) {
+	path := fmt.Sprintf("projects/%s/services", url.PathEscape(projectID))
+	req, err := c.newRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp ListManagedServicesResponse
+	if err := c.do(req, &resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+func (c *Client) DeleteManagedService(ctx context.Context, projectID, serviceID string) error {
+	path := fmt.Sprintf("projects/%s/services/%s", url.PathEscape(projectID), url.PathEscape(serviceID))
+	req, err := c.newRequest(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.do(req, nil)
+}
+
 func (c *Client) newRequest(ctx context.Context, method, path string, body any) (*http.Request, error) {
 	var buf io.Reader
 

--- a/pkg/api/models.go
+++ b/pkg/api/models.go
@@ -97,7 +97,6 @@ type ManagedService struct {
 	Status        string `json:"status"`
 	ContainerName string `json:"containerName,omitempty"`
 	VolumeName    string `json:"volumeName,omitempty"`
-	Message       string `json:"message,omitempty"`
 	CreatedAt     string `json:"createdAt"`
 	UpdatedAt     string `json:"updatedAt"`
 }

--- a/pkg/api/models.go
+++ b/pkg/api/models.go
@@ -87,3 +87,22 @@ type EnvVar struct {
 type SetProjectEnvRequest struct {
 	Variables []EnvVar `json:"variables"`
 }
+
+// ManagedService describes a service attached to a project.
+type ManagedService struct {
+	ID            string `json:"id"`
+	ProjectID     string `json:"projectId"`
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	Status        string `json:"status"`
+	ContainerName string `json:"containerName,omitempty"`
+	VolumeName    string `json:"volumeName,omitempty"`
+	Message       string `json:"message,omitempty"`
+	CreatedAt     string `json:"createdAt"`
+	UpdatedAt     string `json:"updatedAt"`
+}
+
+// ListManagedServicesResponse wraps project managed services.
+type ListManagedServicesResponse struct {
+	Services []ManagedService `json:"services"`
+}


### PR DESCRIPTION
Introducing a dedicated lifecycle management API for managed services, with a focus on PostgreSQL databases. 

It ensures that services have an independent lifecycle from applications, allowing applications to be redeployed or deleted without automatically removing their databases and data. 

The API provides service discovery, status tracking (provisioning, running, error, deleted), and explicit service deletion. 

This lays the foundation for future PostgreSQL provisioning and credential injection while preventing accidental data loss and ensuring compliance with the project requirements.