### PR TITLE
feat: add application health checks for safer deployments

### DIFF
--- a/cmd/server/deployment/apps/docker.go
+++ b/cmd/server/deployment/apps/docker.go
@@ -18,10 +18,16 @@ func (app DockerApp) Prepare(ctx context.Context, docker *dockerw.Client, manife
 	return nil
 }
 
-func (app DockerApp) ContainerConfig(ctx context.Context, manifest manifest.Manifest) dockerw.ContainerConfig {
-	return dockerw.ContainerConfig{
-		Image: app.Image,
+func (app DockerApp) ContainerConfig(ctx context.Context, manifest manifest.Manifest) (dockerw.ContainerConfig, error) {
+	healthcheck, err := healthcheckConfig(app.App)
+	if err != nil {
+		return dockerw.ContainerConfig{}, err
 	}
+
+	return dockerw.ContainerConfig{
+		Image:       app.Image,
+		Healthcheck: healthcheck,
+	}, nil
 }
 
 func NewDockerApp(manifest manifest.DockerApp) DockerApp {

--- a/cmd/server/deployment/apps/dockerfile.go
+++ b/cmd/server/deployment/apps/dockerfile.go
@@ -24,10 +24,16 @@ func (app DockerfileApp) Prepare(ctx context.Context, docker *dockerw.Client, ma
 	return docker.BuildImage(ctx, app.imageTag(manifest), app.Dockerfile, app.Context)
 }
 
-func (app DockerfileApp) ContainerConfig(ctx context.Context, manifest manifest.Manifest) dockerw.ContainerConfig {
-	return dockerw.ContainerConfig{
-		Image: app.imageTag(manifest),
+func (app DockerfileApp) ContainerConfig(ctx context.Context, manifest manifest.Manifest) (dockerw.ContainerConfig, error) {
+	healthcheck, err := healthcheckConfig(app.App)
+	if err != nil {
+		return dockerw.ContainerConfig{}, err
 	}
+
+	return dockerw.ContainerConfig{
+		Image:       app.imageTag(manifest),
+		Healthcheck: healthcheck,
+	}, nil
 }
 
 func NewDockerFileApp(manifest manifest.DockerFileApp, workspace string) DockerfileApp {

--- a/cmd/server/deployment/apps/interface.go
+++ b/cmd/server/deployment/apps/interface.go
@@ -15,5 +15,18 @@ type DeployableApp interface {
 	// Container name and network is managed by the deploy function not this
 	// Env can be populated but the deploy engine will add managed services
 	// environment variables
-	ContainerConfig(ctx context.Context, manifest manifest.Manifest) dockerw.ContainerConfig
+	ContainerConfig(ctx context.Context, manifest manifest.Manifest) (dockerw.ContainerConfig, error)
+}
+
+func healthcheckConfig(app manifest.App) (*dockerw.HealthConfig, error) {
+	if app.Healthcheck == nil {
+		return nil, nil
+	}
+
+	return dockerw.NewHTTPHealthcheck(
+		app.Healthcheck.Path,
+		app.Healthcheck.Port,
+		app.Healthcheck.Interval,
+		app.Healthcheck.Timeout,
+	)
 }

--- a/cmd/server/deployment/apps/static.go
+++ b/cmd/server/deployment/apps/static.go
@@ -42,10 +42,16 @@ func (app StaticWebApp) Prepare(ctx context.Context, docker *dockerw.Client, man
 	return nil
 }
 
-func (app StaticWebApp) ContainerConfig(ctx context.Context, manifest manifest.Manifest) dockerw.ContainerConfig {
-	return dockerw.ContainerConfig{
-		Image: app.imageName(manifest),
+func (app StaticWebApp) ContainerConfig(ctx context.Context, manifest manifest.Manifest) (dockerw.ContainerConfig, error) {
+	healthcheck, err := healthcheckConfig(app.App)
+	if err != nil {
+		return dockerw.ContainerConfig{}, err
 	}
+
+	return dockerw.ContainerConfig{
+		Image:       app.imageName(manifest),
+		Healthcheck: healthcheck,
+	}, nil
 }
 
 func NewStaticWebApp(manifest manifest.StaticWepApp) StaticWebApp {

--- a/cmd/server/deployment/deploy.go
+++ b/cmd/server/deployment/deploy.go
@@ -98,7 +98,10 @@ func DeployProject(projectSlug string, manifest manifest.Manifest, workspaceDir 
 			return err
 		}
 
-		config := app.ContainerConfig(ctx, manifest)
+		config, err := app.ContainerConfig(ctx, manifest)
+		if err != nil {
+			return err
+		}
 
 		config.Env = utils.MergeMap(
 			config.Env,

--- a/internal/dockerw/containers.go
+++ b/internal/dockerw/containers.go
@@ -18,6 +18,7 @@ type ContainerNetwork struct {
 }
 
 type HealthConfig = tcontainer.HealthConfig
+type RestartPolicy = tcontainer.RestartPolicy
 
 type ContainerConfig struct {
 	Image    string
@@ -28,6 +29,8 @@ type ContainerConfig struct {
 	Cmd      []string
 	// Healthcheck uses Docker's native HEALTHCHECK support.
 	Healthcheck *tcontainer.HealthConfig
+	// RestartPolicy defaults to unless-stopped when unset.
+	RestartPolicy *tcontainer.RestartPolicy
 	// ExposedPorts format: "8080/tcp".
 	ExposedPorts []string
 	VolumeBinds  []string
@@ -52,6 +55,10 @@ func (c *Client) containerOptions(cfg ContainerConfig) []container.ContainerCust
 		opts = append(opts, container.WithCmd(cfg.Cmd...))
 	}
 
+	opts = append(opts, container.WithAdditionalHostConfigModifier(func(hostConfig *tcontainer.HostConfig) {
+		hostConfig.RestartPolicy = restartPolicyOrDefault(cfg.RestartPolicy)
+	}))
+
 	if cfg.Healthcheck != nil {
 		opts = append(opts, container.WithAdditionalConfigModifier(func(config *tcontainer.Config) {
 			config.Healthcheck = cfg.Healthcheck
@@ -69,6 +76,14 @@ func (c *Client) containerOptions(cfg ContainerConfig) []container.ContainerCust
 	}
 
 	return opts
+}
+
+func restartPolicyOrDefault(policy *tcontainer.RestartPolicy) tcontainer.RestartPolicy {
+	if policy != nil {
+		return *policy
+	}
+
+	return tcontainer.RestartPolicy{Name: tcontainer.RestartPolicyUnlessStopped}
 }
 
 // ExecInContainer runs a command inside a running container and returns an error if the exit code is non-zero.

--- a/internal/dockerw/containers.go
+++ b/internal/dockerw/containers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/docker/go-sdk/container"
 	tcontainer "github.com/moby/moby/api/types/container"
@@ -16,6 +17,8 @@ type ContainerNetwork struct {
 	Aliases []string
 }
 
+type HealthConfig = tcontainer.HealthConfig
+
 type ContainerConfig struct {
 	Image    string
 	Name     string
@@ -23,6 +26,8 @@ type ContainerConfig struct {
 	Env      map[string]string
 	Labels   map[string]string
 	Cmd      []string
+	// Healthcheck uses Docker's native HEALTHCHECK support.
+	Healthcheck *tcontainer.HealthConfig
 	// ExposedPorts format: "8080/tcp".
 	ExposedPorts []string
 	VolumeBinds  []string
@@ -47,6 +52,12 @@ func (c *Client) containerOptions(cfg ContainerConfig) []container.ContainerCust
 		opts = append(opts, container.WithCmd(cfg.Cmd...))
 	}
 
+	if cfg.Healthcheck != nil {
+		opts = append(opts, container.WithAdditionalConfigModifier(func(config *tcontainer.Config) {
+			config.Healthcheck = cfg.Healthcheck
+		}))
+	}
+
 	if len(cfg.ExposedPorts) > 0 {
 		opts = append(opts, container.WithExposedPorts(cfg.ExposedPorts...))
 	}
@@ -68,6 +79,24 @@ func (c *Client) ExecInContainer(ctx context.Context, containerName string, cmd 
 		return fmt.Errorf("exec in %s: %w: %s", containerName, err, out)
 	}
 	return nil
+}
+
+func NewHTTPHealthcheck(path string, port int, interval string, timeout string) (*tcontainer.HealthConfig, error) {
+	parsedInterval, err := time.ParseDuration(interval)
+	if err != nil {
+		return nil, fmt.Errorf("parse healthcheck interval: %w", err)
+	}
+
+	parsedTimeout, err := time.ParseDuration(timeout)
+	if err != nil {
+		return nil, fmt.Errorf("parse healthcheck timeout: %w", err)
+	}
+
+	return &tcontainer.HealthConfig{
+		Test:     []string{"CMD-SHELL", fmt.Sprintf("wget --no-verbose --tries=1 --spider http://127.0.0.1:%d%s || curl --fail --silent http://127.0.0.1:%d%s >/dev/null", port, path, port, path)},
+		Interval: parsedInterval,
+		Timeout:  parsedTimeout,
+	}, nil
 }
 
 func (c *Client) RunContainerFromConfig(ctx context.Context, config ContainerConfig) error {

--- a/internal/manifest/struct.go
+++ b/internal/manifest/struct.go
@@ -1,7 +1,15 @@
 package manifest
 
 type App struct {
-	Name string `toml:"name"`
+	Name        string       `toml:"name"`
+	Healthcheck *Healthcheck `toml:"healthcheck,omitempty"`
+}
+
+type Healthcheck struct {
+	Path     string `toml:"path"`
+	Port     int    `toml:"port"`
+	Interval string `toml:"interval"`
+	Timeout  string `toml:"timeout"`
 }
 
 type DockerFileApp struct {

--- a/pushnpray.toml.example
+++ b/pushnpray.toml.example
@@ -5,6 +5,12 @@ project-id = 'fd2c7a27-8e47-46a0-bc01-622c12ac8c83'
 name = 'backend'
 image = 'ghcr.io/jdoe/project-backend:latest'
 
+[apps.docker.healthcheck]
+path = '/'
+port = 80
+interval = '2s'
+timeout = '30s'
+
 [[apps.docker]]
 name = 'frontend'
 image = 'ghcr.io/jdoe/project-frontend:latest'


### PR DESCRIPTION
## Summary

Add basic app healthchecks during deployment.

Apps can define a healthcheck in the manifest, and the server now waits for the container HTTP endpoint to respond before marking the deployment as deployed. If the check times out, the deployment fails.